### PR TITLE
Fix AppVeyor caching

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   # Install glslangValidator
   - if not exist C:\projects\deps\glslangValidator git clone --depth 1 https://github.com/KhronosGroup/glslang.git C:\projects\deps\glslangValidator
   - ps: cd C:\projects\deps\glslangValidator; git pull
-  - mkdir C:\projects\deps\glslangValidator\build
+  - if not exist C:\projects\deps\glslangValidator\build mkdir C:\projects\deps\glslangValidator\build
   - ps: cd C:\projects\deps\glslangValidator\build
   - ps: cmake C:\projects\deps\glslangValidator
   - ps: cmake --build C:\projects\deps\glslangValidator\build --config Release --target install


### PR DESCRIPTION
Only attempt to create the folder if it doesn't already exist, apparently mkdir in a command prompt is rather... simplistic.

Best part of this PR? Since it changes `appveyor.yml` it invalidates the cache, thus making it impossible to test the entire reason for the PR.