### PR TITLE
Update the specs for latest glsllangValidator

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
 
   # Install glslangValidator
   - if not exist C:\projects\deps\glslangValidator git clone --depth 1 https://github.com/KhronosGroup/glslang.git C:\projects\deps\glslangValidator
-  - ps: cd C:\projects\deps\glslangValidator; git pull
+  - ps: cd C:\projects\deps\glslangValidator; & cmd /c 'git pull 2>&1'
   - if not exist C:\projects\deps\glslangValidator\build mkdir C:\projects\deps\glslangValidator\build
   - ps: cd C:\projects\deps\glslangValidator\build
   - ps: cmake C:\projects\deps\glslangValidator

--- a/spec/linter-glsl-spec.js
+++ b/spec/linter-glsl-spec.js
@@ -20,7 +20,7 @@ describe('linter-glsl', () => {
     expect(messages[0].type).toEqual('ERROR');
     expect(messages[0].text).toEqual("'vec5' : no matching overloaded function found");
     expect(messages[1].type).toEqual('ERROR');
-    expect(messages[1].text).toEqual("'assign' :  cannot convert from 'const float' to 'fragColor 4-component vector of float FragColor'");
+    expect(messages[1].text).toEqual("'assign' :  cannot convert from ' const float' to ' fragColor 4-component vector of float FragColor'");
     expect(messages[2].type).toEqual('ERROR');
     expect(messages[2].text).toEqual("'' : compilation terminated");
   };


### PR DESCRIPTION
Over in https://github.com/KhronosGroup/glslang/commit/71c100d7c0e3dc970944d56937d713a20ed6e30b the output for certain parts of glslangValidator were changed to have more whitespace in them. Update the specs accordingly.
