### PR TITLE
Return null on failure

### DIFF
--- a/lib/linter-glsl.js
+++ b/lib/linter-glsl.js
@@ -301,8 +301,13 @@ export default {
               ignoreExitCode: true,
             }))
           .then(output => parseGlslValidatorResponse(filesToValidate, output))
-          // eslint-disable-next-line no-console
-          .catch(console.log);
+          .catch((error) => {
+            // eslint-disable-next-line no-console
+            console.error(error);
+            // Since something went wrong executing, return null so
+            // Linter doesn't update any current results
+            return null;
+          });
       },
     };
   },


### PR DESCRIPTION
When something goes wrong creating the temp file or parsing the results just return `null` so Linter doesn't update any current results it has instead of returning `undefined` (which is an invalid response!).

Fixes #57.