### PR TITLE
Handle transform functions

### DIFF
--- a/lib/linter-glsl.js
+++ b/lib/linter-glsl.js
@@ -239,6 +239,8 @@ export default {
         }
       }),
     );
+
+    this.transforms = [];
   },
 
   deactivate() {
@@ -255,7 +257,12 @@ export default {
       lintOnFly: true,
       lint: (activeEditor) => {
         const file = activeEditor.getPath();
-        const content = activeEditor.getText();
+        let content = activeEditor.getText();
+
+        this.transforms.forEach((transform) => {
+          content = transform(file, content);
+        });
+
         let command = this.glslangValidatorPath;
 
         if (this.glslangValidatorPath === undefined) {
@@ -307,6 +314,15 @@ export default {
             // Linter doesn't update any current results
             return null;
           });
+      },
+      addTransform: (transform) => {
+        this.transforms.push(transform);
+      },
+      removeTransform: (transform) => {
+        const index = this.transforms.indexOf(transform);
+        if (index !== -1) {
+          this.transforms.splice(index, 1);
+        }
       },
     };
   },

--- a/spec/fixtures/transform/sample.frag
+++ b/spec/fixtures/transform/sample.frag
@@ -1,0 +1,4 @@
+#version 110
+void main() {
+  gl_FragColor = vec5(1.0, 1.0, 1.0, 1.0);
+}

--- a/spec/linter-glsl-spec.js
+++ b/spec/linter-glsl-spec.js
@@ -4,7 +4,7 @@
 import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 import { join } from 'path';
 
-const { lint } = require('../lib/linter-glsl').provideLinter();
+const { lint, addTransform, removeTransform } = require('../lib/linter-glsl').provideLinter();
 
 const runLint = async (path) => {
   const editor = await atom.workspace.open(path);
@@ -85,6 +85,24 @@ describe('linter-glsl', () => {
     expect(messages[1].type).toEqual('ERROR');
     expect(messages[1].text).toEqual('Missing entry point: Each stage requires one entry point');
   });
+
+  // Transforms
+
+  it('calls transform function', async () => {
+    function transform(path, text) {
+      return text.replace('vec5', 'vec4');
+    }
+
+    const path = join(__dirname, 'fixtures', 'transform', 'sample.frag');
+
+    addTransform(transform);
+    const messagesWith = await runLint(path);
+    expect(messagesWith.length).toEqual(0);
+
+    removeTransform(transform);
+    const messagesWithout = await runLint(path);
+    expect(messagesWithout.length).not.toEqual(0);
+  })
 
   // Vertex shaders
 


### PR DESCRIPTION
I'd like to dig up #68, because I'm using @fand's tool and I'm also stuck when it comes to using glslify. It still doesn't involve sourcemaps within its transform API. Yet I prefer to have error messages which state incorrect line numbers, than no errors at all. Therefore I propose to integrate transform functions as well.

It is meant for glslify but I don't want to force its usage, so it mimics its API. When glslify will work with sourcemaps, this patch should also evolve.

Expected usage: https://github.com/KoltesDigital/veda/commit/a4e6e27bcd22c57132b323a5de260fc1f03a3506